### PR TITLE
feat: optimize compression handling by removing unused structures and improving data validation

### DIFF
--- a/protocol/connect/codec.go
+++ b/protocol/connect/codec.go
@@ -143,6 +143,7 @@ func (m *connectUnaryMarshaler) Marshal(message any) error {
 			return errors.Newf("compress message: %w", err).WithCode(errors.Internal)
 		}
 		if isCompressed {
+			headers.SetHeaderCanonical(m.header, connectUnaryHeaderCompression, m.compressionName)
 			data = compressed
 			compressed.Free()
 		}
@@ -152,7 +153,6 @@ func (m *connectUnaryMarshaler) Marshal(message any) error {
 		return errors.Newf("message size %d exceeds sendMaxBytes %d", data.Len(), m.sendMaxBytes).WithCode(errors.ResourceExhausted)
 	}
 
-	headers.SetHeaderCanonical(m.header, connectUnaryHeaderCompression, m.compressionName)
 	return m.write(data)
 }
 


### PR DESCRIPTION
This pull request refactors compression logic in `compress/compression.go` and updates the handling of headers in `protocol/connect/codec.go`. Key changes include removing unused structs, improving compression efficiency, and fixing header management for compressed messages.

### Compression Logic Refactor (`compress/compression.go`):

* Removed unused `reader` and `writer` structs, simplifying the codebase by eliminating unnecessary abstractions. [[1]](diffhunk://#diff-e3e42763f33e0f2073b2203ccaa195b7e0f7d804b493ce2fabef71509f027388L66-L70) [[2]](diffhunk://#diff-e3e42763f33e0f2073b2203ccaa195b7e0f7d804b493ce2fabef71509f027388L83-R79)
* Enhanced the `Compress` method to:
  - Introduce a minimum compression size (`minCompressionSize`) to avoid compressing small inputs.
  - Validate input data before attempting compression, ensuring it contains meaningful content.
  - Track the number of bytes written and avoid unnecessary compression if the output is larger than the input or no data is written.

### Header Management for Compression (`protocol/connect/codec.go`):

* Adjusted header setting logic in `Marshal` to only set the compression header when compression is successfully applied, ensuring accurate metadata. [[1]](diffhunk://#diff-4d7d7397ab6b16a7b0a59e34ab9fb1c3ce713d4e19c3b6e4d189b02d9f298954R146) [[2]](diffhunk://#diff-4d7d7397ab6b16a7b0a59e34ab9fb1c3ce713d4e19c3b6e4d189b02d9f298954L155)… 